### PR TITLE
3. Dac mv only get

### DIFF
--- a/CtbGui.py
+++ b/CtbGui.py
@@ -112,7 +112,7 @@ class MainWindow(QtWidgets.QMainWindow):
             label.setText(str(self.det.getDAC(dac)[0]))
 
         checkBox.clicked.connect(partial(self.setDACTristate, i))
-        checkBoxmV.clicked.connect(partial(self.setDAC, i))
+        checkBoxmV.clicked.connect(partial(self.getDAC, i))
         spinBox.editingFinished.connect(partial(self.setDAC, i))
 
     def setDAC(self, i):
@@ -1100,7 +1100,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 partial(self.setDAC, i)
             )
             getattr(self, f"checkBoxDAC{i}").clicked.connect(partial(self.setDACTristate, i))
-            getattr(self, f"checkBoxDAC{i}mV").clicked.connect(partial(self.setDAC, i))
+            getattr(self, f"checkBoxDAC{i}mV").clicked.connect(partial(self.getDAC, i))
 
         self.comboBoxADCVpp.activated.connect(self.setADCVpp)
         self.spinBoxHighVoltage.editingFinished.connect(self.setHighVoltage)

--- a/CtbGui.ui
+++ b/CtbGui.ui
@@ -69,7 +69,7 @@
               </size>
              </property>
              <property name="currentIndex">
-              <number>4</number>
+              <number>0</number>
              </property>
              <widget class="QWidget" name="tab">
               <attribute name="title">
@@ -105,6 +105,10 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
+                </property>
                 <property name="text">
                  <string>mV</string>
                 </property>
@@ -117,6 +121,13 @@
                   <width>101</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
                 </property>
                 <property name="text">
                  <string>DAC 5</string>
@@ -144,6 +155,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 3</string>
                 </property>
@@ -156,6 +174,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -184,7 +206,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -203,7 +225,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -221,6 +243,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 15</string>
                 </property>
@@ -233,6 +262,13 @@
                   <width>101</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
                 </property>
                 <property name="text">
                  <string>DAC 17</string>
@@ -247,6 +283,10 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
+                </property>
                 <property name="text">
                  <string>mV</string>
                 </property>
@@ -259,6 +299,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -274,7 +318,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -292,6 +336,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 4</string>
                 </property>
@@ -304,6 +355,13 @@
                   <width>101</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
                 </property>
                 <property name="text">
                  <string>DAC 9</string>
@@ -318,6 +376,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 10</string>
                 </property>
@@ -331,6 +396,10 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
+                </property>
                 <property name="text">
                  <string>mV</string>
                 </property>
@@ -343,6 +412,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -383,6 +456,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 0</string>
                 </property>
@@ -408,6 +488,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -435,6 +519,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 14</string>
                 </property>
@@ -448,6 +539,10 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
+                </property>
                 <property name="text">
                  <string>mV</string>
                 </property>
@@ -460,6 +555,13 @@
                   <width>101</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
                 </property>
                 <property name="text">
                  <string>DAC 8</string>
@@ -487,6 +589,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 1</string>
                 </property>
@@ -499,6 +608,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -513,6 +626,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 13</string>
                 </property>
@@ -525,6 +645,13 @@
                   <width>101</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
                 </property>
                 <property name="text">
                  <string>DAC 7</string>
@@ -553,7 +680,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -585,7 +712,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -603,6 +730,10 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
+                </property>
                 <property name="text">
                  <string>mV</string>
                 </property>
@@ -617,7 +748,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -648,6 +779,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 6</string>
                 </property>
@@ -660,6 +798,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -701,7 +843,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -720,7 +862,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -738,6 +880,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 16</string>
                 </property>
@@ -750,6 +899,13 @@
                   <width>101</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
                 </property>
                 <property name="text">
                  <string>DAC 11</string>
@@ -765,7 +921,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -784,7 +940,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -815,6 +971,10 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
+                </property>
                 <property name="text">
                  <string>mV</string>
                 </property>
@@ -840,6 +1000,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -868,7 +1032,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -887,7 +1051,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -906,7 +1070,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -924,6 +1088,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 12</string>
                 </property>
@@ -938,7 +1109,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -957,7 +1128,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -979,7 +1150,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -998,7 +1169,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1016,6 +1187,10 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
+                </property>
                 <property name="text">
                  <string>mV</string>
                 </property>
@@ -1029,6 +1204,10 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
+                </property>
                 <property name="text">
                  <string>mV</string>
                 </property>
@@ -1041,6 +1220,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -1068,6 +1251,13 @@
                   <height>24</height>
                  </rect>
                 </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Unchecking will set DAC in tristate (sends -100).&lt;br&gt;
+Checking sends nothing to DAC</string>
+                </property>
                 <property name="text">
                  <string>DAC 2</string>
                 </property>
@@ -1080,6 +1270,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>
@@ -1121,7 +1315,7 @@
                  </rect>
                 </property>
                 <property name="toolTip">
-                 <string>Only accepts value range (0 - 4096)</string>
+                 <string>Only accepts value range (0 - 4096). Only modifying this or pressing enter will set DAC.</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1138,6 +1332,10 @@
                   <width>51</width>
                   <height>24</height>
                  </rect>
+                </property>
+                <property name="toolTip">
+                 <string>Checking or unchecking this will only get DAC values on the right (with this condition).&lt;br&gt;
+Only pressing enter on spinbox will set DAC (with this condition).</string>
                 </property>
                 <property name="text">
                  <string>mV</string>


### PR DESCRIPTION
-checking or unechecking mV will only get dac. only pressing enter sets dac or "unchecking" for tristate