### PR TITLE
option for low and fast readouts to handle zmq hwm and buffer size

### DIFF
--- a/CtbGui
+++ b/CtbGui
@@ -64,6 +64,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.refresh_tab_adc()
         self.refresh_tab_pattern()
         self.refresh_tab_acquisition()
+        self.refresh_tab_plot()
 
         # also refreshes timer to start plotting 
         self.plotOptions()
@@ -1148,6 +1149,35 @@ class MainWindow(QtWidgets.QMainWindow):
         self.plotDigitalImage.setColorMap(cm)
         self.plotTransceiverImage.setColorMap(cm)
 
+    def getZMQHWM(self):
+        self.comboBoxZMQHWM.currentIndexChanged.disconnect()
+
+        rx_zmq_hwm = self.det.getRxZmqHwm()[0]
+        # ensure same value in client zmq
+        self.det.setClientZmqHwm(rx_zmq_hwm)
+
+        # high readout, low HWM
+        if rx_zmq_hwm < 25 and rx_zmq_hwm > -1:
+            self.comboBoxZMQHWM.setCurrentIndex(1)
+        # low readout, high HWM
+        else:
+            self.comboBoxZMQHWM.setCurrentIndex(0)
+        self.comboBoxZMQHWM.currentIndexChanged.connect(self.setZMQHWM)
+
+
+    def setZMQHWM(self):
+        val = self.comboBoxZMQHWM.currentIndex()
+        # low readout, high HWM
+        if val == 0:
+            self.det.setRxZmqHwm(Defines.Zmq_hwm_low_speed)
+            self.det.setClientZmqHwm(Defines.Zmq_hwm_low_speed)
+        # high readout, low HWM
+        else:
+            self.det.setRxZmqHwm(Defines.Zmq_hwm_high_speed)
+            self.det.setClientZmqHwm(Defines.Zmq_hwm_high_speed)
+
+        self.getZMQHWM()
+
     def initializeAllAnalogPlots(self):
         self.plotAnalogWaveform = pg.plot()
         self.verticalLayoutPlot.addWidget(self.plotAnalogWaveform, 1)
@@ -2074,6 +2104,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.refresh_tab_pattern()
             case 7:
                 self.refresh_tab_acquisition()
+            case 8:
+                self.refresh_tab_plot()
 
     def refresh_tab_dac(self):
         self.updateDACNames()
@@ -2138,6 +2170,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.getTriggers()
         self.getPeriod()
         self.updateDetectorStatus(self.det.status)
+
+    def refresh_tab_plot(self):
+        self.getZMQHWM()
 
     def setup_zmq(self):
         self.det.rx_zmqstream = 1
@@ -2382,6 +2417,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.radioButtonImage.clicked.connect(self.plotOptions)
         self.comboBoxPlot.currentIndexChanged.connect(self.plotOptions)
         self.comboBoxColorMap.currentIndexChanged.connect(self.setColorMap)
+        self.comboBoxZMQHWM.currentIndexChanged.connect(self.setZMQHWM)
         self.spinBoxSerialOffset.editingFinished.connect(self.setSerialOffset)
         self.spinBoxNCount.editingFinished.connect(self.setNCounter)
         self.spinBoxDynamicRange.editingFinished.connect(self.setDynamicRange)

--- a/CtbGui.ui
+++ b/CtbGui.ui
@@ -17026,7 +17026,7 @@ QPushButton:checked{background-color: red;}</string>
                <property name="geometry">
                 <rect>
                  <x>10</x>
-                 <y>120</y>
+                 <y>160</y>
                  <width>711</width>
                  <height>311</height>
                 </rect>
@@ -17404,7 +17404,7 @@ QPushButton:checked{background-color: red;}</string>
                  <x>10</x>
                  <y>10</y>
                  <width>711</width>
-                 <height>101</height>
+                 <height>141</height>
                 </rect>
                </property>
                <property name="frameShape">
@@ -17655,6 +17655,42 @@ QPushButton:checked{background-color: red;}</string>
                   </property>
                  </spacer>
                 </item>
+                <item row="3" column="0">
+                 <widget class="QLabel" name="labelZMQHWM">
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If set to high readout, zmq HWM is set to 2 and buffer size to 1MB to drop zmq packets to catch up.&lt;/p&gt;&lt;p&gt;If set to low readout (default), zmq HWM is set to zmq default (1000) and buffer size to os default to not drop any zmq packets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <property name="text">
+                   <string>Readout speed:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1" colspan="2">
+                 <widget class="QComboBox" name="comboBoxZMQHWM">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>31</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If set to high readout, zmq HWM is set to 2 and buffer size to 1MB to drop zmq packets to catch up.&lt;/p&gt;&lt;p&gt;If set to low readout (default), zmq HWM is set to zmq default (1000) and buffer size to os default to not drop any zmq packets.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  </property>
+                  <item>
+                   <property name="text">
+                    <string>Low - drop no zmq packet</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>High - drop zmq packets to catch up</string>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
                </layout>
               </widget>
              </widget>
@@ -17705,8 +17741,8 @@ QPushButton:checked{background-color: red;}</string>
    </property>
    <property name="minimumSize">
     <size>
-     <width>0</width>
-     <height>0</height>
+     <width>72</width>
+     <height>80</height>
     </size>
    </property>
    <property name="maximumSize">

--- a/defines.py
+++ b/defines.py
@@ -12,6 +12,9 @@ class Defines():
     Time_Status_Refresh_ms  = 100
     Time_Plot_Refresh_ms = 20
 
+    Zmq_hwm_high_speed = 2
+    Zmq_hwm_low_speed = -1
+
     Acquisition_Tab_Index = 7
     Max_Tabs = 9
 


### PR DESCRIPTION
allow high and low water mark for zmq (also buffer size) for fast readouts