### PR TITLE
bug when enabled is unchecked and plot is checked

### DIFF
--- a/pyctbgui/services/ADC.py
+++ b/pyctbgui/services/ADC.py
@@ -122,10 +122,14 @@ class AdcTab(QtWidgets.QWidget):
 
         waveforms = {}
         analog_array = self._processWaveformData(data, aSamples, self.mainWindow.nADCEnabled)
+        idx = 0
         for i in range(Defines.adc.count):
-            checkBox = getattr(self.view, f"checkBoxADC{i}Plot")
-            if checkBox.isChecked():
-                waveform = analog_array[:, i]
+            checkBoxPlot = getattr(self.view, f"checkBoxADC{i}Plot")
+            checkBoxEn = getattr(self.view, f"checkBoxADC{i}En")
+
+            if checkBoxEn.isChecked() and checkBoxPlot.isChecked():
+                waveform = analog_array[:, idx]
+                idx += 1
                 self.mainWindow.analogPlots[i].setData(waveform)
                 plotName = getattr(self.view, f"labelADC{i}").text()
                 waveforms[plotName] = waveform
@@ -233,7 +237,6 @@ class AdcTab(QtWidgets.QWidget):
                 self.det.adcenable = enableMask
         except Exception as e:
             QtWidgets.QMessageBox.warning(self.mainWindow, "ADC Enable Fail", str(e), QtWidgets.QMessageBox.Ok)
-            pass
 
         self.updateADCEnable()
 

--- a/pyctbgui/services/Transceiver.py
+++ b/pyctbgui/services/Transceiver.py
@@ -102,10 +102,13 @@ class TransceiverTab(QtWidgets.QWidget):
         waveforms = {}
         trans_array = self._processWaveformData(data, dSamples, self.mainWindow.romode.value,
                                                 self.mainWindow.nDBitEnabled, self.nTransceiverEnabled)
+        idx = 0
         for i in range(Defines.transceiver.count):
-            checkBox = getattr(self.view, f"checkBoxTransceiver{i}Plot")
-            if checkBox.isChecked():
-                waveform = trans_array[:, i]
+            checkBoxPlot = getattr(self.view, f"checkBoxTransceiver{i}Plot")
+            checkBoxEn = getattr(self.view, f"checkBoxTransceiver{i}")
+            if checkBoxEn.isChecked() and checkBoxPlot.isChecked():
+                waveform = trans_array[:, idx]
+                idx += 1
                 self.mainWindow.transceiverPlots[i].setData(waveform)
                 plotName = getattr(self.view, f"labelTransceiver{i}").text()
                 waveforms[plotName] = waveform


### PR DESCRIPTION
how to reproduce:
- choose analog waveform
- enable adc 0 and adc1
- enable plot adc0 and adc1
- disable plot adc1
acquire

this will result in index out of bounds error

also can produce a very tricky bug that mismatches plots to their respective adc source (plot adc0 and label it adc1)
same thing for transceiver

